### PR TITLE
simplify logic a bit

### DIFF
--- a/tmpauthenticator/__init__.py
+++ b/tmpauthenticator/__init__.py
@@ -63,6 +63,10 @@ class TmpAuthenticator(Authenticator):
     page immediately logs the user in with a randomly generated UUID if they
     are already not logged in, and spawns a server for them.
     """
+
+    auto_login = True
+    login_service = 'tmp'
+
     force_new_server = Bool(
         False,
         help="""


### PR DESCRIPTION
- call higher-level methods, avoiding need for some workarounds
- correct a few docstrings
- set auto_login flag for future-compatibility with JupyterHub 0.8