### PR TITLE
Compatibility with JupyterHub v1.0.0

### DIFF
--- a/tmpauthenticator/__init__.py
+++ b/tmpauthenticator/__init__.py
@@ -21,7 +21,7 @@ class TmpAuthenticateHandler(BaseHandler):
 
     @gen.coroutine
     def get(self):
-        raw_user = self.get_current_user()
+        raw_user = yield self.get_current_user()
         if raw_user:
             if self.force_new_server and user.running:
                 # Stop user's current server if it is running
@@ -34,7 +34,7 @@ class TmpAuthenticateHandler(BaseHandler):
             raw_user = self.user_from_username(username)
             self.set_login_cookie(raw_user)
         user = yield gen.maybe_future(self.process_user(raw_user, self))
-        self.redirect(self.get_argument("next", user.url))
+        self.redirect(self.get_next_url(user))
 
 
 class TmpAuthenticator(Authenticator):


### PR DESCRIPTION
In the latest version of JupyterHub `get_current_user` is now `async` and throws a runtime warning:
`sys:1: RuntimeWarning: coroutine 'BaseHandler.get_current_user' was never awaited`

This causes `self.redirect(self.get_argument("next", user.url))`
To throw `attributeError: 'coroutine' object has no attribute 'url'`

Also, visiting the user url doesn't implicity launch the user server anymore so adding `self.redirect(self.get_next_url(user))` now reroutes correctly and creates a server automatically.
