### PR TITLE
BREAKING: Logout current user when new user logs in (removes `force_new_server`)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='jupyterhub-tmpauthenticator',
-    version='0.6',
+    version='1.0',
     description='JupyterHub authenticator that hands out temporary accounts for everyone',
     url='https://github.com/jupyterhub/tmpauthenticator',
     author='Yuvi Panda',


### PR DESCRIPTION
tmpauthenticator is primarily used in binder-like cases. When
a user hits /hub/tmplogin, we want them to get a fresh server.
Currently, this could be accomplished with `force_new_server`,
which tries to stop a running server (if any) before logging
new user in.

This has several problems:

1. Stopping servers might fail or take a long time. This shouldn't
   affect the ability to start new servers.
2. This doesn't work with named servers

Instead, we log out the current user first before logging in a
new user. This makes everything much faster & cleaner, at the cost
of leaving the old user's server running. An idle-culler setup
is expected to take care of that.

This is the most common & expected behavior, and a break from the
earlier defaults. Hence this is a breaking change, requiring a new
major version bump.

Inspired by https://github.com/jupyterhub/ltiauthenticator/pull/31

TODO:
- [ ] Add a CHANGELOG
- [x] Bump version