### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-Welcome! As a [Jupyter](https://jupyter.org) project, we follow the [Jupyter contributor guide](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html).
+Welcome! As a [Jupyter](https://jupyter.org) project, we follow the [Jupyter contributor guide](https://docs.jupyter.org/en/latest/contributing/content-contributor.html).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ that gives anyone who visits the home page a user account without having to
 log in using any UI at all. It also spawns a single-user server and directs
 the user to it immediately, without them having to press a button.
 
-Built primarily to help run [tmpnb](https://tmpnb.org) with JupyterHub.
+Built primarily to help run tmpnb with JupyterHub.
 
 ## Installation ##
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ that gives anyone who visits the home page a user account without having to
 log in using any UI at all. It also spawns a single-user server and directs
 the user to it immediately, without them having to press a button.
 
-Built primarily to help run tmpnb with JupyterHub.
+Built primarily to help run [tmpnb](https://github.com/jupyter/tmpnb) with JupyterHub.
 
 ## Installation ##
 


### PR DESCRIPTION
This fixes a broken link in CONTRIBUTING.md and removes the link to tmpnb.org (no longer operated by the jupyter project) in README.md.