### PR TITLE
Fix reference to unbound variable

### DIFF
--- a/tmpauthenticator/__init__.py
+++ b/tmpauthenticator/__init__.py
@@ -23,7 +23,7 @@ class TmpAuthenticateHandler(BaseHandler):
     def get(self):
         raw_user = yield self.get_current_user()
         if raw_user:
-            if self.force_new_server and user.running:
+            if self.force_new_server and raw_user.running:
                 # Stop user's current server if it is running
                 # so we get a new one.
                 status = yield raw_user.spawner.poll_and_notify()


### PR DESCRIPTION
As is, the force_new_server functionality completely fails with:

```
      File "/usr/local/lib/python3.11/site-packages/tornado/web.py", line 1713, in _execute
        result = await result
                 ^^^^^^^^^^^^
      File "/usr/local/lib/python3.11/site-packages/tmpauthenticator/__init__.py", line 26, in get
        if self.force_new_server and user.running:
                                     ^^^^
    UnboundLocalError: cannot access local variable 'user' where it is not associated with a value
```