### PR TITLE
Add tests infrastructure, and automation to run them - no tests yet

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,57 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#
+name: Release
+
+# Always tests wheel building, but only publish to PyPI on pushed tags.
+on:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - ".github/workflows/*.yaml"
+      - "!.github/workflows/release.yaml"
+  push:
+    paths-ignore:
+      - "docs/**"
+      - ".github/workflows/*.yaml"
+      - "!.github/workflows/release.yaml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags: ["**"]
+  workflow_dispatch:
+
+jobs:
+  build-release:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: install build package
+        run: |
+          pip install --upgrade pip
+          pip install build
+          pip freeze
+
+      - name: build release
+        run: |
+          python -m build --sdist --wheel .
+          ls -l dist
+
+      - name: publish to pypi
+        uses: pypa/gh-action-pypi-publish@v1.8.5
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          user: __token__
+          # pypi_password is be a PyPI deployment token for this repo with write
+          # permissions, created by the PyPI account jupyterhub-bot that is a
+          # maintainer for the PyPI project.
+          #
+          # ref: https://github.com/jupyterhub/team-compass/issues/520
+          # ref: https://pypi.org/project/jupyterhub-tmpauthenticator
+          # ref: https://github.com/jupyterhub/tmpauthenticator/settings/secrets/actions.
+          #
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,65 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#
+name: Tests
+
+on:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - ".github/workflows/*.yaml"
+      - "!.github/workflows/test.yaml"
+  push:
+    paths-ignore:
+      - "docs/**"
+      - ".github/workflows/*.yaml"
+      - "!.github/workflows/test.yaml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags: ["**"]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # oldest supported python and jupyterhub version
+          - python-version: "3.7"
+            jupyterhub-version: "1.3.0"
+
+          - python-version: "3.8"
+            jupyterhub-version: "1.*"
+          - python-version: "3.9"
+            jupyterhub-version: "2.*"
+          - python-version: "3.10"
+            jupyterhub-version: "3.*"
+          - python-version: "3.11"
+            jupyterhub-version: "4.*"
+
+          # latest version of python and jupyterhub (including pre-releases)
+          - python-version: "3.x"
+            jupyterhub-version: "*"
+            pip-install-flags: --pre
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ matrix.python-version }}"
+
+      - name: Install Python dependencies
+        run: |
+          pip install ${{ matrix.pip-install-flags }} "jupyterhub==${{ matrix.jupyterhub-version }}"
+          pip install ".[test]"
+          pip freeze
+
+      - name: Run tests
+        run: |
+          pytest --cov=jupyterhub-tmpauthenticator
+
+      - uses: codecov/codecov-action@v3

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,61 @@
+# How to make a release
+
+`jupyterhub-tmpauthenticator` is a package available on [PyPI].
+
+These are the instructions on how to make a release.
+
+## Pre-requisites
+
+- Push rights to this GitHub repository
+
+## Steps to make a release
+
+1. Create a PR updating `CHANGELOG.md` with [github-activity] and continue when
+   its merged.
+
+   Advice on this procedure can be found in [this team compass
+   issue](https://github.com/jupyterhub/team-compass/issues/563).
+
+2. Checkout main and make sure it is up to date.
+
+   ```shell
+   git checkout main
+   git fetch origin main
+   git reset --hard origin/main
+   ```
+
+3. Update the version, make commits, and push a git tag with `tbump`.
+
+   ```shell
+   pip install tbump
+   ```
+
+   ```shell
+   # Example versions to set: 1.0.0, 1.0.0b1
+   VERSION=
+
+   tbump --dry-run ${VERSION}
+   ```
+
+   ```shell
+   tbump ${VERSION}
+   ```
+
+   Following this, the [CI system] will build and publish a release.
+
+4. Reset the version back to dev, e.g. `1.0.1.dev` after releasing `1.0.0`.
+
+   ```shell
+   # Example version to set: 1.0.1.dev
+   NEXT_VERSION=
+
+   tbump --dry-run --no-tag ${NEXT_VERSION}.dev
+   ```
+
+   ```shell
+   tbump --no-tag ${NEXT_VERSION}.dev
+   ```
+
+[github-activity]: https://github.com/executablebooks/github-activity
+[pypi]: https://pypi.org/project/jupyterhub-tmpauthenticator/
+[ci system]: https://github.com/jupyterhub/jupyterhub-tmpauthenticator/actions/workflows/release.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,16 @@ target_version = [
 profile = "black"
 
 
+# pytest is used for running Python based tests
+#
+# ref: https://docs.pytest.org/en/stable/
+#
+[tool.pytest.ini_options]
+addopts = "--verbose --color=yes --durations=10"
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+
 # tbump is used to simplify and standardize the release process when updating
 # the version, making a git commit and tag, and pushing changes.
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,32 @@ target_version = [
 #
 [tool.isort]
 profile = "black"
+
+
+# tbump is used to simplify and standardize the release process when updating
+# the version, making a git commit and tag, and pushing changes.
+#
+# ref: https://github.com/your-tools/tbump#readme
+#
+[tool.tbump]
+github_url = "https://github.com/jupyterhub/tmpauthenticator"
+
+[tool.tbump.version]
+current = "1.0.0.dev"
+regex = '''
+    (?P<major>\d+)
+    \.
+    (?P<minor>\d+)
+    \.
+    (?P<patch>\d+)
+    (?P<pre>((a|b|rc)\d+)|)
+    \.?
+    (?P<dev>(?<=\.)dev\d*|)
+'''
+
+[tool.tbump.git]
+message_template = "Bump to {new_version}"
+tag_template = "{new_version}"
+
+[[tool.tbump.file]]
+src = "setup.py"

--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,15 @@ setup(
     author_email='yuvipanda@gmail.com',
     license='3 Clause BSD',
     packages=find_packages(),
+    python_requires=">=3.7",
+    install_require={
+        "jupyterhub>=1.3.0",
+    },
+    extras_require={
+        "test": [
+            "pytest",
+            "pytest-asyncio",
+            "pytest-cov",
+        ],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='jupyterhub-tmpauthenticator',
-    version='1.0',
+    version='1.0.0.dev',
     description='JupyterHub authenticator that hands out temporary accounts for everyone',
     url='https://github.com/jupyterhub/tmpauthenticator',
     author='Yuvi Panda',

--- a/tests/test_tmpauthenticator.py
+++ b/tests/test_tmpauthenticator.py
@@ -1,0 +1,12 @@
+"""
+Test ideas:
+
+- Validate that TmpAuthenticateHandler.get() creates a new user.
+- Validate that TmpAuthenticateHandler.get() creates a new user and updates the
+  login cookie even if it was already set.
+- Validate that TmpAuthenticateHandler.get() redirects to something sensible.
+
+Bonus:
+
+- Test process_user by creating a subclass doing something.
+"""


### PR DESCRIPTION
I didn't get down to writing tests, a bit uncertain on how - but with the example jupyterhub_config.py added in #42 I feel a bit more confident.

@yuvipanda should we go for a merge on this instead of #43? Both PRs add jupyterhub as a dependency and will have merge conflicts. I figure we should have a lower bound on what jupyterhub version we support, and I no longer remember if there was a reason I picked 1.3.0 or what reason it was, but I recall seeing something around that as a lower bound in other projects.

- Closes #43 