### PR TITLE
maint: update docstrings and import maybe_future from jupyterhub

### DIFF
--- a/tmpauthenticator/__init__.py
+++ b/tmpauthenticator/__init__.py
@@ -1,8 +1,9 @@
+import inspect
 import uuid
 
 from jupyterhub.auth import Authenticator
 from jupyterhub.handlers import BaseHandler
-from jupyterhub.utils import maybe_future, url_path_join
+from jupyterhub.utils import url_path_join
 
 
 class TmpAuthenticateHandler(BaseHandler):
@@ -38,7 +39,9 @@ class TmpAuthenticateHandler(BaseHandler):
         # Let a subclasses of TmpAuthenticator process the new user by
         # overriding TmpAuthenticator.process_user.
         #
-        user = await maybe_future(self.process_user(user, self))
+        user = self.process_user(user, self)
+        if inspect.isawaitable(user):
+            user = await user
 
         # Set or overwrite the login cookie to recognize the new user.
         #

--- a/tmpauthenticator/__init__.py
+++ b/tmpauthenticator/__init__.py
@@ -2,15 +2,16 @@ import uuid
 
 from jupyterhub.auth import Authenticator
 from jupyterhub.handlers import BaseHandler
-from jupyterhub.utils import url_path_join
-from tornado import gen
+from jupyterhub.utils import maybe_future, url_path_join
 
 
 class TmpAuthenticateHandler(BaseHandler):
     """
     Handler for /tmplogin
 
-    Creates a new user with a random UUID, and auto starts their server
+    Creates a new user with a random UUID as username and ensures cookies are
+    updated to let JupyterHub recognize future requests as coming from the newly
+    created user.
     """
 
     def initialize(self, process_user):
@@ -27,26 +28,44 @@ class TmpAuthenticateHandler(BaseHandler):
         login mechanism. This only happens when /tmplogin is hit - so you can use
         other parts of the hub as you normally would.
         """
+        # Create a new user.
+        #
+        # user_from_username ref: https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/handlers/base.py#L504-L505
+        #
         username = str(uuid.uuid4())
         user = self.user_from_username(username)
-        user = await gen.maybe_future(self.process_user(user, self))
-        self.set_login_cookie(user)
 
-        # This sets a hub login cookie for the new user, overwriting old user's cookies if needed
+        # Let a subclasses of TmpAuthenticator process the new user by
+        # overriding TmpAuthenticator.process_user.
+        #
+        user = await maybe_future(self.process_user(user, self))
+
+        # Set or overwrite the login cookie to recognize the new user.
+        #
+        # set_login_cookie(user) sets a login cookie for the provided user via
+        # set_hub_cookie(user), but only if it doesn't recognize a user from an
+        # pre-existing login cookie. Due to that, we unconditionally call
+        # self.set_hub_cookie(user) here.
+        #
+        # set_login_cookie ref: https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/handlers/base.py#L627-L628
+        # set_hub_cookie ref:   https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/handlers/base.py#L623-L625
+        #
+        self.set_login_cookie(user)
         self.set_hub_cookie(user)
 
+        # Login complete, redirect the user.
+        #
+        # get_next_url ref: https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/handlers/base.py#L646-L653
+        #
         next_url = self.get_next_url(user)
-
         self.redirect(next_url)
 
 
 class TmpAuthenticator(Authenticator):
     """
-    JupyterHub Authenticator for use with tmpnb.org
-
     When JupyterHub is configured to use this authenticator, visiting the home
-    page immediately logs the user in with a randomly generated UUID if they
-    are already not logged in, and spawns a server for them.
+    page immediately logs the user in with a randomly generated UUID if they are
+    already not logged in, and spawns a server for them.
     """
 
     auto_login = True
@@ -60,7 +79,7 @@ class TmpAuthenticator(Authenticator):
 
         Should return the new user object.
 
-        This method can be a @tornado.gen.coroutine.
+        This method can be a coroutine.
 
         Note: This is primarily for overriding in subclasses
         """


### PR DESCRIPTION
Besides importing maybe_future from jupyterhub instead of using tornado.gen.maybe_future, this is just updating the docstrings and inline comments to clarify things in a bit more detail.

The jupyterhub code base doesn't use gen.maybe_future, but instead the self defined jupyterhub.utils.maybe_future function that references different implementations based on different situations for compatibility. See https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/utils.py#L572-L596.