### PR TITLE
Register tmp authenticator with JupyterHub via entry_points

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ Should install it. It has no additional dependencies beyond JupyterHub.
 You can then use this as your authenticator by adding the following line to
 your `jupyterhub_config.py`:
 
-```
-c.JupyterHub.authenticator_class = tmpauthenticator.TmpAuthenticator
+```python
+c.JupyterHub.authenticator_class = "tmp"
 ```

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,16 @@ setup(
     author='Yuvi Panda',
     author_email='yuvipanda@gmail.com',
     license='3 Clause BSD',
+    entry_points={
+        # Thanks to this, user are able to do:
+        #
+        #     c.JupyterHub.authenticator_class = "tmp"
+        #
+        # ref: https://jupyterhub.readthedocs.io/en/4.0.0/reference/authenticators.html#registering-custom-authenticators-via-entry-points
+        #
+        'jupyterhub.authenticators': [
+            'tmp = tmpauthenticator:TmpAuthenticator',
+        ],
+    },
     packages=find_packages(),
 )


### PR DESCRIPTION
Following this, users should be able to do `c.JupyterHub.authenticator_class = "tmp"`.

- Closes #20