### PR TITLE
Document how to present /hub/login, make auto_login and login_service configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,20 @@
+# Manually added parts to .gitignore
+# ----------------------------------
+#
+
+# JupyterHub running for development purposes
+jupyterhub-proxy.pid
+jupyterhub.sqlite
+jupyterhub_cookie_secret
+
+# Editors
+.vscode
+.idea
+
+
+# Python .gitignore from https://github.com/github/gitignore/blob/HEAD/Python.gitignore
+# -------------------------------------------------------------------------------------
+#
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -8,7 +25,6 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
 build/
 develop-eggs/
 dist/
@@ -20,9 +36,12 @@ lib64/
 parts/
 sdist/
 var/
+wheels/
+share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -37,13 +56,17 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.nox/
 .coverage
 .coverage.*
 .cache
 nosetests.xml
 coverage.xml
-*,cover
+*.cover
+*.py,cover
 .hypothesis/
+.pytest_cache/
+cover/
 
 # Translations
 *.mo
@@ -51,12 +74,104 @@ coverage.xml
 
 # Django stuff:
 *.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
 
 # Sphinx documentation
 docs/_build/
 
 # PyBuilder
+.pybuilder/
 target/
 
-#Ipython Notebook
+# Jupyter Notebook
 .ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/README.md
+++ b/README.md
@@ -21,3 +21,33 @@ your `jupyterhub_config.py`:
 ```python
 c.JupyterHub.authenticator_class = "tmp"
 ```
+
+## Configuration
+
+`tmpauthenticator` does not have a lot of configurable knobs, but will respect
+many relevant config options in the [base JupyterHub Authenticator class](https://jupyterhub.readthedocs.io/en/stable/reference/api/auth.html).
+Here are a few that are particularly useful.
+
+### `TmpAuthenticator.auto_login`
+
+By default, `tmpauthenticator` will automatically log the user in as soon
+as they hit the landing page of the JupyterHub, without showing them any UI.
+This behavior can be turned off by setting `TmpAuthenticator.auto_login` to
+`False`, allowing a home page to be shown. There will be a `Sign in` button here
+that will automatically authenticate the user.
+
+```python
+c.TmpAuthenticator.auto_login = False
+```
+
+### `TmpAuthenticator.login_service`
+
+If `auto_login` is set to `False`, the value of `TmpAuthenticator.login_service`
+will determine the text shown next to `Sign in` in the default home page. It
+defaults to `Automatic Temporary Credentials, so the button will read as
+`Sign in with Automatic Temporary Credentials`.
+
+```python
+c.TmpAuthenticator.auto_login = False
+c.TmpAuthenticator.login_service = "your inherent worth as a human being"
+```

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -4,8 +4,8 @@ sample jupyterhub config file for testing tmpauthenticator
 
 c = get_config()  # noqa
 
-c.JupyterHub.authenticator_class = "tmp"
+c.JupyterHub.authenticator_class = "tmp"  # TmpAuthenticator
+c.JupyterHub.spawner_class = "simple"  # SimpleLocalProcessSpawner
 
-from jupyterhub.spawner import SimpleLocalProcessSpawner
-
-c.JupyterHub.spawner_class = SimpleLocalProcessSpawner
+# c.TmpAuthenticator.auto_login = False
+# c.TmpAuthenticator.login_service = "your inherent worth as a human being"

--- a/tmpauthenticator/__init__.py
+++ b/tmpauthenticator/__init__.py
@@ -4,7 +4,7 @@ import uuid
 from jupyterhub.auth import Authenticator
 from jupyterhub.handlers import BaseHandler
 from jupyterhub.utils import url_path_join
-from traitlets import default
+from traitlets import Unicode, default
 
 
 class TmpAuthenticateHandler(BaseHandler):
@@ -87,8 +87,19 @@ class TmpAuthenticator(Authenticator):
         """
         return True
 
-    # Text to be shown with the 'Sign in with...' button, when auto_login is False
-    login_service = 'Automatic Temporary Credentials'
+    login_service = Unicode(
+        "Automatic Temporary Credentials",
+        help="""
+        Text to be shown with the 'Sign in with ...' button, when auto_login is
+        False.
+
+        The Authenticator base class' login_service isn't tagged as a
+        configurable traitlet, so we redefine it to allow it to be configurable
+        like this:
+
+            c.TmpAuthenticator.login_service = "your inherent worth as a human being"
+        """,
+    ).tag(config=True)
 
     def process_user(self, user, handler):
         """

--- a/tmpauthenticator/__init__.py
+++ b/tmpauthenticator/__init__.py
@@ -4,6 +4,7 @@ import uuid
 from jupyterhub.auth import Authenticator
 from jupyterhub.handlers import BaseHandler
 from jupyterhub.utils import url_path_join
+from traitlets import default
 
 
 class TmpAuthenticateHandler(BaseHandler):
@@ -71,10 +72,20 @@ class TmpAuthenticator(Authenticator):
     already not logged in, and spawns a server for them.
     """
 
-    # Default to automatically logging in the user when they hit the hub's
-    # home page, without requiring them to click a 'login' button. Can be
-    # overriden in config if you want to explicitly show the home page.
-    auto_login = True
+    @default("auto_login")
+    def _auto_login_default(self):
+        """
+        The Authenticator base class' config auto_login defaults to False, but
+        we change that default to True in TmpAuthenticator. This makes users
+        automatically get logged in when they hit the hub's home page, without
+        requiring them to click a 'login' button.
+
+        JupyterHub admins can still opt back to present the /hub/login page with
+        the login button like this:
+
+            c.TmpAuthenticator.auto_login = False
+        """
+        return True
 
     # Text to be shown with the 'Sign in with...' button, when auto_login is False
     login_service = 'Automatic Temporary Credentials'

--- a/tmpauthenticator/__init__.py
+++ b/tmpauthenticator/__init__.py
@@ -71,8 +71,13 @@ class TmpAuthenticator(Authenticator):
     already not logged in, and spawns a server for them.
     """
 
+    # Default to automatically logging in the user when they hit the hub's
+    # home page, without requiring them to click a 'login' button. Can be
+    # overriden in config if you want to explicitly show the home page.
     auto_login = True
-    login_service = 'tmp'
+
+    # Text to be shown with the 'Sign in with...' button, when auto_login is False
+    login_service = 'Automatic Temporary Credentials'
 
     def process_user(self, user, handler):
         """


### PR DESCRIPTION
Since auto_login and login_service are configurable traitlets from the base class, we have only been setting the default here - it does not prevent them from being set in config.

Fixes https://github.com/jupyterhub/tmpauthenticator/issues/40