### PR TITLE
Remove process_user and fix support for post_auth_hook

### DIFF
--- a/tests/test_tmpauthenticator.py
+++ b/tests/test_tmpauthenticator.py
@@ -5,8 +5,4 @@ Test ideas:
 - Validate that TmpAuthenticateHandler.get() creates a new user and updates the
   login cookie even if it was already set.
 - Validate that TmpAuthenticateHandler.get() redirects to something sensible.
-
-Bonus:
-
-- Test process_user by creating a subclass doing something.
 """

--- a/tests/test_tmpauthenticator.py
+++ b/tests/test_tmpauthenticator.py
@@ -5,4 +5,5 @@ Test ideas:
 - Validate that TmpAuthenticateHandler.get() creates a new user and updates the
   login cookie even if it was already set.
 - Validate that TmpAuthenticateHandler.get() redirects to something sensible.
+- Validate that a configured post_auth_hook is executed.
 """

--- a/tmpauthenticator/__init__.py
+++ b/tmpauthenticator/__init__.py
@@ -8,49 +8,47 @@ from traitlets import Unicode, default
 
 class TmpAuthenticateHandler(BaseHandler):
     """
-    Handler for /tmplogin which is registered by TmpAuthenticator.
+    Provides a GET web request handler for /hub/tmplogin, as registered by
+    TmpAuthenticator's override of Authenticator.get_handlers.
 
-    Creates a new user with a random UUID as username and ensures cookies are
-    updated to let JupyterHub recognize future requests as coming from the newly
-    created user.
+    JupyterHub will redirect here if it doesn't recognize a user via a cookie,
+    but users can also visit /hub/tmplogin explicitly to get setup with a new
+    user.
     """
 
     async def get(self):
         """
-        Authenticate as a new user.
+        Authenticate as a new random user no matter what.
 
-        Each time /tmplogin is hit, we want to create a brand new user. This lets
-        users hit the hub URL, and immediately get a new server - regardless of wether
-        they had already logged in or not. So /tmplogin really acts as a logout +
-        login mechanism. This only happens when /tmplogin is hit - so you can use
-        other parts of the hub as you normally would.
+        This GET request handler mimics parts of what's done by JupyterHub's
+        LoginHandler when a user isn't recognized: to first call
+        BaseHandler.login_user and then redirect the user onwards. The
+        difference is that here users always login as a new user.
+
+        By overwriting any previous user's identifying cookie, it acts as a
+        combination of a logout and login handler.
+
+        JupyterHub's LoginHandler ref: https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/handlers/login.py#L129-L138
         """
-        username = str(uuid.uuid4())
-
-        # Run post_auth_hook
+        # Login as a new user, without checking if we were already logged in
         #
-        # Authenticator.run_post_auth_hook ref: https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/auth.py#L400-L418
-        #
-        authenticated = {"name": username}
-        authenticated = await self.authenticator.run_post_auth_hook(self, authenticated)
-
-        # Create a new user
-        #
-        # BaseHandler.auth_to_user ref: https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/handlers/base.py#L774-L821
-        #
-        user = await self.auth_to_user(authenticated)
+        user = await self.login_user(None)
 
         # Set or overwrite the login cookie to recognize the new user.
         #
-        # set_login_cookie(user) sets a login cookie for the provided user via
-        # set_hub_cookie(user), but only if it doesn't recognize a user from an
-        # pre-existing login cookie. Due to that, we unconditionally call
-        # self.set_hub_cookie(user) here.
+        # login_user calls set_login_cookie(user), that sets a login cookie for
+        # the user via set_hub_cookie(user), but only if it doesn't recognize a
+        # user from an pre-existing login cookie. Due to that, we
+        # unconditionally call self.set_hub_cookie(user) here.
         #
-        # BaseHandler.set_login_cookie ref: https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/handlers/base.py#L627-L628
-        # BaseHandler.set_hub_cookie ref:   https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/handlers/base.py#L623-L625
+        # BaseHandler.login_user:                   https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/handlers/base.py#L823-L843
+        # - BaseHandler.authenticate:               https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/handlers/base.py#L643-L644
+        #   - Authenticator.get_authenticated_user: https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/auth.py#L472-L534
+        # - BaseHandler.auth_to_user:               https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/handlers/base.py#L774-L821
+        # - BaseHandler.set_login_cookie:           https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/handlers/base.py#L627-L628
+        #   - BaseHandler.set_session_cookie:       https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/handlers/base.py#L601-L613
+        #   - BaseHandler.set_hub_cookie:           https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/handlers/base.py#L623-L625
         #
-        self.set_login_cookie(user)
         self.set_hub_cookie(user)
 
         # Login complete, redirect the user.
@@ -97,11 +95,21 @@ class TmpAuthenticator(Authenticator):
         """,
     ).tag(config=True)
 
+    async def authenticate(self, handler, data):
+        """
+        Always authenticate a new user by generating a universally unique
+        identifier (uuid).
+        """
+        username = str(uuid.uuid4())
+        return {
+            "name": username,
+        }
+
     def get_handlers(self, app):
         """
         Registers a dedicated endpoint and web request handler for logging in
-        with tmpauthenticator. This is needed as /hub/login is reserved for
-        redirecting to whats returned by login_url.
+        with TmpAuthenticator. This is needed as /hub/login is reserved for
+        redirecting to what's returned by login_url.
 
         ref: https://github.com/jupyterhub/jupyterhub/pull/1066
         """
@@ -109,9 +117,14 @@ class TmpAuthenticator(Authenticator):
 
     def login_url(self, base_url):
         """
-        login_url is overridden as intended for Authenticator subclasses by
-        jupyterhub to redirected users to it when they visit /hub/login.
+        login_url is overridden as intended for Authenticator subclasses that
+        provides a custom login handler (for /hub/tmplogin).
+
+        JupyterHub redirects users to this destination from /hub/login if
+        auto_login is set, or if its not set and users press the "Sign in ..."
+        button.
 
         ref: https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/auth.py#L708-L723
+        ref: https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/handlers/login.py#L118-L147
         """
-        return url_path_join(base_url, 'tmplogin')
+        return url_path_join(base_url, "tmplogin")


### PR DESCRIPTION
- Closes #39

I suggest we remove this feature straight up as part of the first major release. JupyterHub admin users can make use of post_auth_hook still, and subclass developers could do whatever they want still.

### For the changelog

The `TmpAuthenticator.process_user` function is no longer provided for subclasses to override. The configurable [`Authenticator.post_auth_hook`](https://jupyterhub.readthedocs.io/en/stable/reference/api/auth.html#jupyterhub.auth.Authenticator.post_auth_hook) can be used to accomplish the same things though.