### PR TITLE
Add tests, require py38 and jupyterhub 2.3+

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,11 +7,13 @@ on:
   pull_request:
     paths-ignore:
       - "docs/**"
+      - "**.md"
       - ".github/workflows/*.yaml"
       - "!.github/workflows/test.yaml"
   push:
     paths-ignore:
       - "docs/**"
+      - "**.md"
       - ".github/workflows/*.yaml"
       - "!.github/workflows/test.yaml"
     branches-ignore:
@@ -60,6 +62,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest --cov=jupyterhub-tmpauthenticator
+          pytest --cov=tmpauthenticator
 
+      # GitHub action reference: https://github.com/codecov/codecov-action
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,9 +32,9 @@ jobs:
         include:
           # oldest supported python and jupyterhub version
           - python-version: "3.8"
-            pip-install-spec: "jupyterhub==2.0.0"
+            pip-install-spec: "jupyterhub==2.0.0 sqlalchemy==1.*"
           - python-version: "3.9"
-            pip-install-spec: "jupyterhub==2.*"
+            pip-install-spec: "jupyterhub==2.* sqlalchemy==1.*"
           - python-version: "3.10"
             pip-install-spec: "jupyterhub==3.*"
           - python-version: "3.11"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
         include:
           # oldest supported python and jupyterhub version
           - python-version: "3.8"
-            pip-install-spec: "jupyterhub==2.0.0 sqlalchemy==1.*"
+            pip-install-spec: "jupyterhub==2.3.0 sqlalchemy==1.*"
           - python-version: "3.9"
             pip-install-spec: "jupyterhub==2.* sqlalchemy==1.*"
           - python-version: "3.10"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,11 +31,8 @@ jobs:
       matrix:
         include:
           # oldest supported python and jupyterhub version
-          - python-version: "3.7"
-            jupyterhub-version: "1.3.0"
-
           - python-version: "3.8"
-            jupyterhub-version: "1.*"
+            jupyterhub-version: "2.0.0"
           - python-version: "3.9"
             jupyterhub-version: "2.*"
           - python-version: "3.10"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,28 +32,34 @@ jobs:
         include:
           # oldest supported python and jupyterhub version
           - python-version: "3.8"
-            jupyterhub-version: "2.0.0"
+            pip-install-spec: "jupyterhub==2.0.0"
           - python-version: "3.9"
-            jupyterhub-version: "2.*"
+            pip-install-spec: "jupyterhub==2.*"
           - python-version: "3.10"
-            jupyterhub-version: "3.*"
+            pip-install-spec: "jupyterhub==3.*"
           - python-version: "3.11"
-            jupyterhub-version: "4.*"
+            pip-install-spec: "jupyterhub==4.*"
 
           # latest version of python and jupyterhub (including pre-releases)
           - python-version: "3.x"
-            jupyterhub-version: "*"
-            pip-install-flags: --pre
+            pip-install-spec: "--pre jupyterhub"
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
       - uses: actions/setup-python@v4
         with:
           python-version: "${{ matrix.python-version }}"
 
+      - name: Install Node dependencies
+        run: |
+          npm install -g configurable-http-proxy
+
       - name: Install Python dependencies
         run: |
-          pip install ${{ matrix.pip-install-flags }} "jupyterhub==${{ matrix.jupyterhub-version }}"
+          pip install ${{ matrix.pip-install-spec }}
           pip install ".[test]"
           pip freeze
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ remove-unused-variables = true
 [tool.black]
 skip-string-normalization = true
 target_version = [
-    "py37",
     "py38",
     "py39",
     "py310",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     packages=find_packages(),
     python_requires=">=3.8",
     install_require={
-        "jupyterhub>=2.0.0",
+        "jupyterhub>=2.3.0",
         "traitlets",
     },
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -20,15 +20,18 @@ setup(
         ],
     },
     packages=find_packages(),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_require={
-        "jupyterhub>=1.3.0",
+        "jupyterhub>=2.0.0",
+        "traitlets",
     },
     extras_require={
         "test": [
+            "aiohttp",
             "pytest",
             "pytest-asyncio",
             "pytest-cov",
+            "pytest-jupyterhub",
         ],
     },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+import aiohttp
+import pytest
+from traitlets.config import Config
+from yarl import URL
+
+# pytest-jupyterhub provides a pytest-plugin, and from it we get various
+# fixtures, where we make use of hub_app that builds on MockHub, which defaults
+# to providing a MockSpawner.
+#
+# ref: https://github.com/jupyterhub/pytest-jupyterhub
+# ref: https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/tests/mocking.py#L224
+#
+pytest_plugins = [
+    "jupyterhub-spawners-plugin",
+]
+
+@pytest.fixture
+async def hub_config():
+    """
+    Represents the base configuration of relevance to test TmpAuthenticator.
+    """
+    config = Config()
+    config.JupyterHub.authenticator_class = "tmp"
+    return config
+
+@pytest.fixture
+async def browser_session():
+    """
+    Returns a ClientSession object from aiohttp, allowing cookies to be stored
+    in between requests etc, allowing us to simulate a browser.
+
+    ref: https://docs.aiohttp.org/en/stable/client_reference.html#client-session
+    ref: https://docs.aiohttp.org/en/stable/client_reference.html#response-object
+    """
+    browser_session = aiohttp.ClientSession()
+    try:
+        yield browser_session
+    finally:
+        await browser_session.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import aiohttp
 import pytest
 from traitlets.config import Config
-from yarl import URL
 
 # pytest-jupyterhub provides a pytest-plugin, and from it we get various
 # fixtures, where we make use of hub_app that builds on MockHub, which defaults
@@ -14,6 +13,7 @@ pytest_plugins = [
     "jupyterhub-spawners-plugin",
 ]
 
+
 @pytest.fixture
 async def hub_config():
     """
@@ -21,7 +21,13 @@ async def hub_config():
     """
     config = Config()
     config.JupyterHub.authenticator_class = "tmp"
+
+    # yarl or aiohttp used in tests doesn't handle escaped URLs correctly, so
+    # the MockHub prefix of "/@/space%20word/" must be updated to workaround it.
+    config.JupyterHub.base_url = "/prefix/"
+
     return config
+
 
 @pytest.fixture
 async def browser_session():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,8 +38,5 @@ async def browser_session():
     ref: https://docs.aiohttp.org/en/stable/client_reference.html#client-session
     ref: https://docs.aiohttp.org/en/stable/client_reference.html#response-object
     """
-    browser_session = aiohttp.ClientSession()
-    try:
+    async with aiohttp.ClientSession() as browser_session:
         yield browser_session
-    finally:
-        await browser_session.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ async def hub_config():
 
 
 @pytest.fixture
-async def browser_session():
+async def web_client_session():
     """
     Returns a ClientSession object from aiohttp, allowing cookies to be stored
     in between requests etc, allowing us to simulate a browser.
@@ -38,5 +38,5 @@ async def browser_session():
     ref: https://docs.aiohttp.org/en/stable/client_reference.html#client-session
     ref: https://docs.aiohttp.org/en/stable/client_reference.html#response-object
     """
-    async with aiohttp.ClientSession() as browser_session:
-        yield browser_session
+    async with aiohttp.ClientSession() as web_client_session:
+        yield web_client_session

--- a/tests/test_tmpauthenticator.py
+++ b/tests/test_tmpauthenticator.py
@@ -3,7 +3,6 @@ Test ideas:
 
 - Validate that TmpAuthenticateHandler.get() creates a new user and updates the
   login cookie even if it was already set.
-- Validate that a configured post_auth_hook is executed.
 """
 import pytest
 from yarl import URL
@@ -62,3 +61,40 @@ async def test_login(
     r = await browser_session.get(home_url)
 
     assert r.status == 200
+
+
+@pytest.mark.parametrize(
+    "test_setting_admin_to, test_status",
+    [
+        (True, 200),
+        (False, 403),
+    ],
+)
+async def test_post_auth_hook_config(
+    hub_app,
+    hub_config,
+    browser_session,
+    test_setting_admin_to,
+    test_status,
+):
+    """
+    Tests that the inherited Authenticator.post_auth_hook is respected by
+    updating the authentication dictionary's admin key and accessing /hub/admin,
+    which should result in a forbidden response if not configured as admin via
+    the post_auth_hook.
+    """
+
+    def set_admin_post_auth_hook(authenticator, handler, authentication):
+        authentication["admin"] = test_setting_admin_to
+        return authentication
+
+    hub_config.TmpAuthenticator.post_auth_hook = set_admin_post_auth_hook
+
+    app = await hub_app(hub_config)
+    app_port = URL(app.bind_url).port
+    app_url = URL(f"http://localhost:{app_port}{app.base_url}")
+
+    admin_url = str(app_url / "hub/admin")
+    r = await browser_session.get(admin_url)
+
+    assert r.status == test_status

--- a/tests/test_tmpauthenticator.py
+++ b/tests/test_tmpauthenticator.py
@@ -7,3 +7,42 @@ Test ideas:
 - Validate that TmpAuthenticateHandler.get() redirects to something sensible.
 - Validate that a configured post_auth_hook is executed.
 """
+import pytest
+from yarl import URL
+
+
+@pytest.mark.parametrize(
+    "test_config, test_status, test_location, test_url",
+    [
+        ({}, 302, "hub/tmplogin", None),
+        ({"TmpAuthenticator": {"auto_login": True}}, 302, "hub/tmplogin", None),
+        ({"TmpAuthenticator": {"auto_login": False}}, 200, None, "hub/login"),
+    ],
+)
+async def test_auto_login_config(
+    hub_app,
+    hub_config,
+    browser_session,
+    test_config,
+    test_status,
+    test_location,
+    test_url,
+):
+    """
+    Tests TmpAuthenticator.auto_login's behavior when its default value is used,
+    and when its explicitly set.
+    """
+    hub_config.merge(test_config)
+
+    app = await hub_app(hub_config)
+    app_port = URL(app.bind_url).port
+    app_url = URL(f"http://localhost:{app_port}{app.base_url}")
+
+    login_url = str(app_url / "hub/login")
+    r = await browser_session.get(login_url, allow_redirects=False)
+
+    assert r.status == test_status
+    if test_url:
+        assert test_url in str(r.url)
+    if test_location:
+        assert test_location in r.headers["Location"]

--- a/tests/test_tmpauthenticator.py
+++ b/tests/test_tmpauthenticator.py
@@ -1,10 +1,8 @@
 """
 Test ideas:
 
-- Validate that TmpAuthenticateHandler.get() creates a new user.
 - Validate that TmpAuthenticateHandler.get() creates a new user and updates the
   login cookie even if it was already set.
-- Validate that TmpAuthenticateHandler.get() redirects to something sensible.
 - Validate that a configured post_auth_hook is executed.
 """
 import pytest
@@ -46,3 +44,21 @@ async def test_auto_login_config(
         assert test_url in str(r.url)
     if test_location:
         assert test_location in r.headers["Location"]
+
+
+async def test_login(
+    hub_app,
+    hub_config,
+    browser_session,
+):
+    """
+    Tests that the user is redirected and finally authorized for /hub/home
+    """
+    app = await hub_app(hub_config)
+    app_port = URL(app.bind_url).port
+    app_url = URL(f"http://localhost:{app_port}{app.base_url}")
+
+    home_url = str(app_url / "hub/home")
+    r = await browser_session.get(home_url)
+
+    assert r.status == 200

--- a/tests/test_tmpauthenticator.py
+++ b/tests/test_tmpauthenticator.py
@@ -2,7 +2,7 @@ import pytest
 from yarl import URL
 
 
-async def _get_username(browser_session, app_url):
+async def _get_username(web_client_session, app_url):
     """
     Visits /hub/home to get an _xsrf token set to cookies, that we can then
     pass as a X-XSRFToken header when accessing /hub/api, then the function
@@ -13,10 +13,10 @@ async def _get_username(browser_session, app_url):
     home_url = str(app_url / "hub/home")
     api_user_url = str(app_url / "hub/api/user")
 
-    r = await browser_session.get(home_url)
+    r = await web_client_session.get(home_url)
     assert r.status == 200
 
-    hub_cookies = browser_session.cookie_jar.filter_cookies(home_url)
+    hub_cookies = web_client_session.cookie_jar.filter_cookies(home_url)
     if "_xsrf" in hub_cookies:
         _xsrf = hub_cookies["_xsrf"].value
     else:
@@ -27,7 +27,7 @@ async def _get_username(browser_session, app_url):
         "Accept": "application/json",
     }
 
-    r = await browser_session.get(api_user_url, headers=headers)
+    r = await web_client_session.get(api_user_url, headers=headers)
     assert r.status == 200
     user_api_response = await r.json()
     return user_api_response["name"]
@@ -44,7 +44,7 @@ async def _get_username(browser_session, app_url):
 async def test_auto_login_config(
     hub_app,
     hub_config,
-    browser_session,
+    web_client_session,
     test_config,
     test_status,
     test_location,
@@ -61,7 +61,7 @@ async def test_auto_login_config(
     app_url = URL(f"http://localhost:{app_port}{app.base_url}")
 
     login_url = str(app_url / "hub/login")
-    r = await browser_session.get(login_url, allow_redirects=False)
+    r = await web_client_session.get(login_url, allow_redirects=False)
 
     assert r.status == test_status
     if test_url:
@@ -73,7 +73,7 @@ async def test_auto_login_config(
 async def test_login(
     hub_app,
     hub_config,
-    browser_session,
+    web_client_session,
 ):
     """
     Tests that the user is redirected and finally authorized for /hub/home.
@@ -83,7 +83,7 @@ async def test_login(
     app_url = URL(f"http://localhost:{app_port}{app.base_url}")
 
     home_url = str(app_url / "hub/home")
-    r = await browser_session.get(home_url)
+    r = await web_client_session.get(home_url)
 
     assert r.status == 200
 
@@ -98,7 +98,7 @@ async def test_login(
 async def test_post_auth_hook_config(
     hub_app,
     hub_config,
-    browser_session,
+    web_client_session,
     test_setting_admin_to,
     test_status,
 ):
@@ -120,7 +120,7 @@ async def test_post_auth_hook_config(
     app_url = URL(f"http://localhost:{app_port}{app.base_url}")
 
     admin_url = str(app_url / "hub/admin")
-    r = await browser_session.get(admin_url)
+    r = await web_client_session.get(admin_url)
 
     assert r.status == test_status
 
@@ -128,7 +128,7 @@ async def test_post_auth_hook_config(
 async def test_revisit_tmplogin(
     hub_app,
     hub_config,
-    browser_session,
+    web_client_session,
 ):
     """
     Tests that we get a new user if visiting /hub/tmplogin, even if we already
@@ -143,17 +143,17 @@ async def test_revisit_tmplogin(
     app_url = URL(f"http://localhost:{app_port}{app.base_url}")
 
     # first access, so we receive a new user
-    first_username = await _get_username(browser_session, app_url)
+    first_username = await _get_username(web_client_session, app_url)
     assert first_username
 
     # when we visit /hub/home again, we are recognized and that doesn't make us
     # arrive at /hub/login -> /hub/tmplogin, and therefore we shouldn't get a
     # new user
-    assert first_username == await _get_username(browser_session, app_url)
+    assert first_username == await _get_username(web_client_session, app_url)
 
     # we visit /hub/tmplogin and should get a _new_ user
     tmplogin_url = str(app_url / "hub/tmplogin")
-    r = await browser_session.get(tmplogin_url)
+    r = await web_client_session.get(tmplogin_url)
     assert r.status == 200
-    second_username = await _get_username(browser_session, app_url)
+    second_username = await _get_username(web_client_session, app_url)
     assert first_username != second_username


### PR DESCRIPTION
- Closes #26

We are going for 1.0.0, so dropping support for a jupyterhub version or python 3.7 doesn't seem problematic, so I'm doing that. `pytest-jupyterhub` requires py38 and jupyterhub 2+, and I concluded that we observed test failures with jupyterhub 2.0-2.2 but not with 2.3, so I put a lower bound on that.