### PR TITLE
setup.py: update author, comment about being founded by Yuvi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ setup(
     version='1.0.0.dev',
     description='JupyterHub authenticator that hands out temporary accounts for everyone',
     url='https://github.com/jupyterhub/tmpauthenticator',
-    author='Yuvi Panda',
-    author_email='yuvipanda@gmail.com',
+    author="Project Jupyter Contributors",  # founded by Yuvi Panda
+    author_email="jupyter@googlegroups.com",
     license='3 Clause BSD',
     entry_points={
         # Thanks to this, user are able to do:


### PR DESCRIPTION
Addresses @manics comment in https://github.com/jupyterhub/tmpauthenticator/issues/30#issuecomment-1516934080.

I concluded that setup.py doesn't allow us to specify multiple strings based on https://stackoverflow.com/questions/9999829/how-to-specify-multiple-authors-emails-in-setup-py, but I think pyproject.toml does, and one use comma separation etc still.

@yuvipanda @minrk @manics what do you think?

I looked around a few repos and found traefik-proxy and binderhub used this author/author_email, and jupyterhub used "Jupyter Development Team".