### PR TITLE
ci: fix coverage report by installing as editable

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install ${{ matrix.pip-install-spec }}
-          pip install ".[test]"
+          pip install -e ".[test]"
           pip freeze
 
       - name: Run tests


### PR DESCRIPTION
When we write `pytest --cov=tmpauthenticator` we are pointing to the local folder and its .py files. But those are not relevant if we haven't done `pip install -e .`, because then what is consumed from tests doing `from tmpauthenticator import ...` is from some other location.